### PR TITLE
Add support for multicolumn unique validators

### DIFF
--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -1,4 +1,9 @@
 from __future__ import absolute_import
+from collections import Iterable, Mapping
+
+import six
+from sqlalchemy import Column
+from sqlalchemy.orm.attributes import InstrumentedAttribute
 try:
     from validators import email
 except ImportError:
@@ -163,10 +168,18 @@ class DateRange(BaseDateTimeRange):
 
 
 class Unique(object):
-    """Checks field value unicity against specified table field.
+    """Checks field values unicity against specified table fields.
 
     :param column:
-        InstrumentedAttribute object, eg. User.name
+        InstrumentedAttribute object, eg. User.name, or
+        Column object, eg. user.c.name, or
+        a field name, eg. 'name' or
+        a tuple of InstrumentedAttributes, eg. (User.name, User.email) or
+        a dictionary mapping field names to InstrumentedAttributes, eg.
+        {
+            'name': User.name,
+            'email': User.email
+        }
     :param get_session:
         A function that returns a SQAlchemy Session. This parameter is not
         needed if the given model supports Flask-SQLAlchemy styled query
@@ -177,25 +190,63 @@ class Unique(object):
     field_flags = ('unique', )
 
     def __init__(self, column, get_session=None, message=None):
-        self.model = column.class_
         self.column = column
         self.message = message
         self.get_session = get_session
 
-        if not hasattr(self.model, 'query') and not get_session:
-            raise Exception('Could not obtain SQLAlchemy session.')
+        # Check if we can obtain SQLAlchemy session
+        if isinstance(self.column, Mapping):
+            self._check_for_session(
+                next(six.itervalues(self.column)).class_
+            )
+        elif (
+            isinstance(self.column, Iterable) and
+            not isinstance(self.column[0], six.string_types) and
+            isinstance(self.column[0], Iterable)
+        ):
+            self._check_for_session(self.column[0][1].class_)
+        elif isinstance(self.column, InstrumentedAttribute):
+            self._check_for_session(self.column.class_)
 
     @property
     def query(self):
+        self._check_for_session(self.model)
         if hasattr(self.model, 'query'):
             return getattr(self.model, 'query')
         return self.get_session().query(self.model)
 
+    def _check_for_session(self, model):
+        if not hasattr(model, 'query') and not self.get_session:
+            raise Exception('Could not obtain SQLAlchemy session.')
+
+    def _syntaxes_as_tuples(self, form, field, column):
+        """Converts a set of different syntaxes into a tuple of tuples"""
+        if isinstance(column, six.string_types):
+            return ((column, getattr(form.Meta.model, column)),)
+        elif isinstance(column, Mapping):
+            return tuple(
+                (x[0], self._syntaxes_as_tuples(form, field, x[1])[0][1])
+                for x in column.items()
+            )
+        elif isinstance(column, Iterable):
+            return tuple(
+                self._syntaxes_as_tuples(form, field, x)[0]
+                for x in column
+            )
+        elif isinstance(column, InstrumentedAttribute):
+            return ((column.name, column),)
+        elif isinstance(column, Column):
+            return ((column.key, column),)
+        else:
+            raise TypeError("Invalid syntax for column")
+
     def __call__(self, form, field):
-        obj = (
-            self.query
-            .filter(self.column == field.data).first()
-        )
+        columns = self._syntaxes_as_tuples(form, field, self.column)
+        self.model = columns[0][1].class_
+        query = self.query
+        for field_name, column in columns:
+            query = query.filter(column == form[field_name].data)
+        obj = query.first()
 
         if not hasattr(form, '_obj') or (obj and not form._obj == obj):
             if self.message is None:


### PR DESCRIPTION
Unique validator now supports a set of different syntaxes:
- InstrumentedAttribute object, eg. User.name, or
-  Column object, eg. user.c.name, or
- a field name, eg. 'name' or
- a tuple of InstrumentedAttributes, eg. (User.name, User.email) or
- a dictionary mapping field names to InstrumentedAttributes, eg. { 'name': User.name, 'email': User.email }
