### PR TITLE
Fix broken Unique

### DIFF
--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -239,9 +239,7 @@ class Unique(object):
                 self._syntaxes_as_tuples(form, field, x)[0]
                 for x in column
             )
-        elif isinstance(column, InstrumentedAttribute):
-            return ((column.name, column),)
-        elif isinstance(column, Column):
+        elif isinstance(column, (Column, InstrumentedAttribute)):
             return ((column.key, column),)
         else:
             raise TypeError("Invalid syntax for column")


### PR DESCRIPTION
This pull request fixes several problems with the Unique validator.
- InstrumentedAttributes were not working correctly (https://github.com/kvesteri/wtforms-components/issues/13). The test that was suppose to test this wasn't working correctly.
- Avoid failing silently if wrong syntax is given, e.g. Unique('name', 'email') instead of Unique(('name', 'email'))
- Add more tests for better test coverage
