### PR TITLE
Add base_form argument to SplitDateTimeField

### DIFF
--- a/tests/fields/test_split_date_time_field.py
+++ b/tests/fields/test_split_date_time_field.py
@@ -1,6 +1,7 @@
 from datetime import date, datetime, time
 
 from wtforms_components.fields import SplitDateTimeField
+from wtforms import Form
 from wtforms.validators import DataRequired
 
 from tests import MultiDict, SimpleFieldTestCase
@@ -79,3 +80,15 @@ class TestSplitDateTimeField(SimpleFieldTestCase):
         }))
         assert form.test_field.data['date'] == date(2000, 3, 2)
         assert form.test_field.data['time'] == time(19, 10)
+
+    def test_default_base_form(self):
+        form_class = self.init_form()
+        form = form_class()
+        assert form.test_field.form.__class__.__bases__ == (Form,)
+
+    def test_custom_base_form(self):
+        class A(Form):
+            pass
+        form_class = self.init_form(datetime_form={'base_form': A})
+        form = form_class()
+        assert form.test_field.form.__class__.__bases__ == (A,)

--- a/wtforms_components/fields/split_date_time.py
+++ b/wtforms_components/fields/split_date_time.py
@@ -54,8 +54,9 @@ def datetime_form(options):
     options.setdefault('time', {})
     options['date'].setdefault('label', u'Date')
     options['time'].setdefault('label', u'Time')
+    base_form = options.pop('base_form', Form)
 
-    class DateTimeForm(Form):
+    class DateTimeForm(base_form):
         date = DateField(**options['date'])
         time = TimeField(**options['time'])
     return DateTimeForm


### PR DESCRIPTION
Added option to define base_form for DateTimeForm in SplitDateTimeField.
