### PR TITLE
Fix Unique validator's session check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Here you can see the full list of changes between each WTForms-Components
 release.
 
 
+0.9.6 (2014-09-04)
+^^^^^^^^^^^^^^^^^^
+
+- Fixed Unique validator session checking (#19).
+
+
 0.9.5 (2014-07-31)
 ^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ for name, requirements in extras_require.items():
 
 setup(
     name='WTForms-Components',
-    version='0.9.5',
+    version='0.9.6',
     url='https://github.com/kvesteri/wtforms-components',
     license='BSD',
     author='Konsta Vesterinen',

--- a/tests/test_unique_validator.py
+++ b/tests/test_unique_validator.py
@@ -81,13 +81,14 @@ class TestUniqueValidator(DatabaseTestCase):
         (('name', User.name),)
     ))
     def test_raises_exception_if_improperly_configured(self, column):
+        class MyForm(ModelForm):
+            name = TextField(
+                validators=[Unique(
+                    column,
+                )]
+            )
         with raises(Exception):
-            class MyForm(ModelForm):
-                name = TextField(
-                    validators=[Unique(
-                        column,
-                    )]
-                )
+            MyForm().validate()
 
     def test_raises_exception_string_if_improperly_configured(self):
         class MyForm(ModelForm):

--- a/wtforms_components/__init__.py
+++ b/wtforms_components/__init__.py
@@ -29,7 +29,7 @@ from .validators import DateRange, Unique, If, Chain, Email, TimeRange
 from .widgets import ReadOnlyWidgetProxy, NumberInput, SelectWidget
 
 
-__version__ = '0.9.5'
+__version__ = '0.9.6'
 
 
 __all__ = (

--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -194,20 +194,6 @@ class Unique(object):
         self.message = message
         self.get_session = get_session
 
-        # Check if we can obtain SQLAlchemy session
-        if isinstance(self.column, Mapping):
-            self._check_for_session(
-                next(six.itervalues(self.column)).class_
-            )
-        elif (
-            isinstance(self.column, Iterable) and
-            not isinstance(self.column[0], six.string_types) and
-            isinstance(self.column[0], Iterable)
-        ):
-            self._check_for_session(self.column[0][1].class_)
-        elif isinstance(self.column, InstrumentedAttribute):
-            self._check_for_session(self.column.class_)
-
     @property
     def query(self):
         self._check_for_session(self.model)


### PR DESCRIPTION
Consider the following module:

``` python
from wtforms_components import ModelForm, Unique

class UserForm(ModelForm):
    name = TextField()
    email = TextField(validators=[
        Unique(
            User.email,
            get_session=lambda: db.session
        )
    ])
```

where `db` is an instance of `flask.ext.sqlalchemy:SQLAlchemy`.
Attempting to just import the module previously raised `RuntimeError`
because session was checked in `Unique.__init__`:

``` pytb
Traceback (most recent call last):
  File "user_form.py", line 3, in <module>
    class UserForm(ModelForm):
  File "user_form.py", line 8, in UserEditForm
    get_session=lambda: db.session
  File "env/lib/python3.4/site-packages/wtforms_components/validators.py", line 209, in __init__
    self._check_for_session(self.column.class_)
  File "env/lib/python3.4/site-packages/wtforms_components/validators.py", line 225, in _check_for_session
    if not hasattr(model, 'query') and not self.get_session:
  File "env/lib/python3.4/site-packages/flask_sqlalchemy/__init__.py", line 428, in __get__
    return type.query_class(mapper, session=self.sa.session())
  File "env/lib/python3.4/site-packages/sqlalchemy/orm/scoping.py", line 71, in __call__
    return self.registry()
  File "env/lib/python3.4/site-packages/sqlalchemy/util/_collections.py", line 910, in __call__
    return self.registry.setdefault(key, self.createfunc())
  File "env/lib/python3.4/site-packages/flask_sqlalchemy/__init__.py", line 136, in __init__
    self.app = db.get_app()
  File "env/lib/python3.4/site-packages/flask_sqlalchemy/__init__.py", line 809, in get_app
    raise RuntimeError('application not registered on db '
RuntimeError: application not registered on db instance and no application bound to current context
```

I removed the session check from `__init__`. Now it's checked when
the `Unique` validator is actually called.
