### PR TITLE
Add support for Unique validator in non model forms, closes #34

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,9 @@ python:
 env:
   matrix:
     - WTFORMS=WTForms==1.0.5
-    - WTFORMS=wtforms2
+    - WTFORMS=WTForms~=2.1
 
 install:
-  - "if [ $WTFORMS = wtforms2 ]; then export WTFORMS=https://github.com/wtforms/wtforms/archive/master.zip; fi"
   - "pip install $WTFORMS"
   - pip install -e ".[test]"
 script:

--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
         '#egg=phonenumbers3k-5.6b1',
     ],
     install_requires=[
-        'WTForms>=1.0.4',
+        'WTForms >= 1.0.4, < 3',
         'SQLAlchemy>=0.8.0',
         'SQLAlchemy-Utils>=0.23.0',
         'six>=1.4.1',

--- a/tests/test_unique_validator.py
+++ b/tests/test_unique_validator.py
@@ -2,6 +2,7 @@ import sqlalchemy as sa
 from pytest import mark, raises
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
+from wtforms import Form
 from wtforms.ext.sqlalchemy.fields import QuerySelectField
 from wtforms.fields import TextField
 
@@ -335,6 +336,19 @@ class TestUniqueValidator(DatabaseTestCase):
         User.query = self.session.query(User)
 
         class MyForm(ModelForm):
+            name = TextField(
+                validators=[Unique(
+                    User.name,
+                )]
+            )
+
+        form = MyForm(MultiDict({'name': u'someone'}))
+        assert form.validate()
+
+    def test_supports_naked_wtforms_form(self):
+        User.query = self.session.query(User)
+
+        class MyForm(Form):
             name = TextField(
                 validators=[Unique(
                     User.name,

--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -239,7 +239,7 @@ class Unique(object):
             query = query.filter(column == form[field_name].data)
         obj = query.first()
 
-        if not hasattr(form, '_obj') or (obj and not form._obj == obj):
+        if obj and obj != getattr(form, '_obj', None):
             if self.message is None:
                 self.message = field.gettext(u'Already exists.')
             raise ValidationError(self.message)


### PR DESCRIPTION
Resolve candidate for #34
Do not require form to define `_obj` attribute.
Assume that no previous object exists if `_obj` is missing.

Other possibility would be to raise Exception when user tries to validate a form without the `_obj` attribute. Still, I think it is safe to assume, that user has not provided object for edit if `_obj` attribute is missing.