### PR TITLE
Convert readthedocs links for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -9,7 +9,7 @@ Additional fields, validators and widgets for WTForms.
 Resources
 ---------
 
-- `Documentation <http://wtforms-components.readthedocs.org/>`_
+- `Documentation <https://wtforms-components.readthedocs.io/>`_
 - `Issue Tracker <http://github.com/kvesteri/wtforms-components/issues>`_
 - `Code <http://github.com/kvesteri/wtforms-components/>`_
 


### PR DESCRIPTION
As per [their blog post of the 27th April](https://blog.readthedocs.com/securing-subdomains/) ‘Securing subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.