### PR TITLE
Make SelectWidget backwards compatible

### DIFF
--- a/tests/test_widgets.py
+++ b/tests/test_widgets.py
@@ -1,0 +1,48 @@
+from wtforms import Form
+from wtforms.fields import SelectField
+from wtforms_test import FormTestCase
+
+from wtforms_components import SelectWidget
+
+
+class Dummy(object):
+    fruits = None
+
+
+class TestSelectWidgetWithNativeSelect(FormTestCase):
+    choices = (
+        ('apple', 'Apple'),
+        ('peach', 'Peach'),
+        ('pear', 'Pear'),
+        ('cucumber', 'Cucumber'),
+        ('potato', 'Potato'),
+        ('tomato', 'Tomato'),
+    )
+
+    def init_form(self, **kwargs):
+        class TestForm(Form):
+            fruit = SelectField(widget=SelectWidget(), **kwargs)
+
+        self.form_class = TestForm
+        return self.form_class
+
+    def test_option_selected(self):
+        form_class = self.init_form(choices=self.choices)
+
+        obj = Dummy()
+        obj.fruit = 'peach'
+        form = form_class(
+            obj=obj
+        )
+        assert (
+            '<option selected value="peach">Peach</option>' in
+            str(form.fruit)
+        )
+
+    def test_default_value(self):
+        form_class = self.init_form(choices=self.choices, default='pear')
+        form = form_class()
+        assert (
+            '<option selected value="pear">Pear</option>' in
+            str(form.fruit)
+        )

--- a/wtforms_components/widgets.py
+++ b/wtforms_components/widgets.py
@@ -259,11 +259,15 @@ class SelectWidget(_Select):
         if isinstance(label, (list, tuple)):
             return cls.render_optgroup(value, label, mixed)
 
-        coerce_func, data = mixed
-        if isinstance(data, list) or isinstance(data, tuple):
-            selected = coerce_func(value) in data
+        try:
+            coerce_func, data = mixed
+        except TypeError:
+            selected = mixed
         else:
-            selected = coerce_func(value) == data
+            if isinstance(data, list) or isinstance(data, tuple):
+                selected = coerce_func(value) in data
+            else:
+                selected = coerce_func(value) == data
 
         options = {'value': value}
 


### PR DESCRIPTION
Make SelectWidget backwards compatible with native SelectField.

I had a weird problem.
I had a widget inherited from wtforms `Select` widget. I noticed that I need to support optgroup's. 
Well, that was easy. I just replaced the `Select` widget with WTForms-Components `SelectWidget`. 
After that, I noticed that the inherited widget was used with WTForms-Alchemy `QuerySelectField`, which inherits from WTForms `SelectFieldBase`.
This did not work, because the the `SelectFieldBase` does not pass `coarce` function as third parameter when iterating values.

I solved this by adding a fallback to `render_option` method, that allows calling it with WTForms type of arguments. 
