### PR TITLE
Missing comma in code example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -97,7 +97,7 @@ code and display format as parameters.
 
     class UserForm(Form):
         phone_number = PhoneNumberField(
-            country_code='FI'
+            country_code='FI',
             display_format='national'
         )
 


### PR DESCRIPTION
Adds missing comma in code example of `PhoneNumberField`.