### PR TITLE
Add universal wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,5 @@
+[bdist_wheel]
+universal = 1
+
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
Allows calling:
python setup.py sdist bdist_wheel
twine upload dist/*

to relase both source and binary (universal wheel) distribution of the package.

Wheels are faster to install. We can use universal wheels because we do not have C extensions.