### PR TITLE
Fix issue with color widget defaulting to black for named colors

### DIFF
--- a/wtforms_components/fields/color.py
+++ b/wtforms_components/fields/color.py
@@ -19,7 +19,7 @@ class ColorField(StringField):
         if self.raw_data:
             return self.raw_data[0]
         if self.data:
-            return str(self.data)
+            return str(self.data.hex_l)
         else:
             return u''
 


### PR DESCRIPTION
The color input only works with long hexadecimal color notation. When converting a Color object to string, the colour package will automatically convert to the smallest possible web format including named colors and short hex notation, resulting in the default black color in the color widget. This change forces the value to be written in long hex format.