### PR TITLE
Drop whitelist argument from email validator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 language: python
 python:
-  - 2.7
   - 3.4
   - 3.5
   - 3.6
@@ -18,8 +17,6 @@ env:
     - WTFORMS=WTForms==3.0.0a1
 jobs:
   exclude:
-    - python: 2.7
-      env: WTFORMS=WTForms==3.0.0a1
     - python: 3.4
       env: WTFORMS=WTForms==3.0.0a1
     - python: 3.5

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ UNRELEASED
 ^^^^^^^^^^
 
 - Drop whitelist argument from email validator (#75, pull request courtesy tvuotila)
+- Dropper Python 2.7 support
 
 
 0.10.5 (2021-01-17)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Here you can see the full list of changes between each WTForms-Components
 release.
 
 
+UNRELEASED
+^^^^^^^^^^
+
+- Drop whitelist argument from email validator (#75, pull request courtesy tvuotila)
+
+
 0.10.5 (2021-01-17)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setup(
         'WTForms>=1.0.4',
         'six>=1.4.1',
         'email_validator>=1.0.0',
-        'validators>=0.5.0' if PY3 else 'validators<=0.15',
+        'validators>=0.21',
         'intervals>=0.6.0',
         'MarkupSafe>=1.0.0'
     ],

--- a/setup.py
+++ b/setup.py
@@ -7,12 +7,10 @@ Additional fields, validators and widgets for WTForms.
 
 import os
 import re
-import sys
 
 from setuptools import setup
 
 HERE = os.path.dirname(os.path.abspath(__file__))
-PY3 = sys.version_info[0] == 3
 
 
 def get_version():
@@ -31,7 +29,7 @@ extras_require = {
         'isort==4.3.21',
     ],
     'color': ['colour>=0.0.4'],
-    'ipaddress': ['ipaddr'] if not PY3 else [],
+    'ipaddress': [],
     'timezone': ['python-dateutil'],
 }
 
@@ -73,16 +71,16 @@ setup(
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
+    ],
+    python_requires='>=3.4'
 )

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py37, py26-wtforms2, py27-wtforms2, py34-wtforms2, py35-wtforms2, py36-wtforms2, py37-wtforms2
+envlist = py37, py34-wtforms2, py35-wtforms2, py36-wtforms2, py37-wtforms2
 
 [testenv]
 commands = pip install -e ".[test]"
@@ -12,16 +12,6 @@ commands = pip install -e ".[test]"
 install_command = pip install {packages}
 deps =
      WTForms==1.0.5
-
-[testenv:py26-wtforms2]
-basepython = python2.6
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
-
-[testenv:py27-wtforms2]
-basepython = python2.7
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
 
 [testenv:py34-wtforms2]
 basepython = python3.4

--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -165,28 +165,20 @@ class DateRange(BaseDateTimeRange):
 
 class Email(object):
     """
-    Validates an email address. This validator is based on `Django's
-    email validator`_ and is stricter than the standard email
+    Validates an email address.
+    This validator is is stricter than the standard email
     validator included in WTForms.
-
-    .. _Django's email validator:
-       https://github.com/django/django/blob/master/django/core/validators.py
 
     :param message:
         Error message to raise in case of a validation error.
-
-    :copyright: (c) Django Software Foundation and individual contributors.
-    :license: BSD
     """
-    domain_whitelist = ['localhost']
 
-    def __init__(self, message=None, whitelist=None):
+    def __init__(self, message=None):
         self.message = message
-        if whitelist is not None:
-            self.domain_whitelist = whitelist
 
     def __call__(self, form, field):
-        if not email(field.data, self.domain_whitelist):
-            if self.message is None:
-                self.message = field.gettext(u'Invalid email address.')
-            raise ValidationError(self.message)
+        if not email(field.data):
+            message = self.message
+            if message is None:
+                message = field.gettext(u'Invalid email address.')
+            raise ValidationError(message)


### PR DESCRIPTION
Fixes #73

Drops Python 2.7 support as the required `validators` version doesn't support Python 2.7. 