### PR TITLE
Update Tox configuration

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,31 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37, py34-wtforms2, py35-wtforms2, py36-wtforms2, py37-wtforms2
+envlist = {py39,py310,py311,py312}-{wtforms23,wtforms31}
 
 [testenv]
-commands = pip install -e ".[test]"
-           py.test
-install_command = pip install {packages}
+commands =
+    pytest {posargs}
 deps =
-     WTForms==1.0.5
-
-[testenv:py34-wtforms2]
-basepython = python3.4
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
-
-[testenv:py35-wtforms2]
-basepython = python3.5
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
-
-[testenv:py36-wtforms2]
-basepython = python3.6
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
-
-[testenv:py37-wtforms2]
-basepython = python3.7
-deps =
-     https://github.com/wtforms/wtforms/archive/wtforms2.zip
+    .[test]
+    wtforms23: WTForms>=2.3,<2.4
+    wtforms31: WTForms>=3.1,<3.2


### PR DESCRIPTION
Update Tox configuration to test the project against Python versions that have active security support. Remove the environment that tested against WTForms 1 because it does not support Python 3.8 or newer. Instead, test against WTForms 2.3 and 3.1.