### PR TITLE
Update the supported Python versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
           - python: "3.11"
           - python: "3.10"
           - python: "3.9"
-          - python: "3.8"
 
     steps:
       - uses: actions/checkout@v4

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,7 +9,8 @@ UNRELEASED
 ^^^^^^^^^^
 
 - Drop whitelist argument from email validator (#75, pull request courtesy tvuotila)
-- Dropper Python 2.7 support
+- Add support for Python 3.9, 3.10, 3.11 and 3.12.
+- Drop support for Python 3.8 or older.
 
 
 0.10.5 (2021-01-17)

--- a/setup.py
+++ b/setup.py
@@ -72,15 +72,15 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.4',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
         'Programming Language :: Python :: 3 :: Only',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
         'Topic :: Software Development :: Libraries :: Python Modules'
     ],
-    python_requires='>=3.4'
+    python_requires='>=3.9'
 )


### PR DESCRIPTION
Add support for Python 3.9, 3.10, 3.11 and 3.12. Drop support for Python 3.8 or older.