### PR TITLE
Add support for WTForms 3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,5 +31,5 @@ jobs:
 
       - name: Run tests
         env:
-          TOXENV: py-wtforms23, py-wtforms31
+          TOXENV: py-wtforms31, py-wtforms32
         run: tox

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,7 @@ UNRELEASED
 - Drop whitelist argument from email validator (#75, pull request courtesy tvuotila)
 - Add support for Python 3.9, 3.10, 3.11 and 3.12.
 - Drop support for Python 3.8 or older.
+- Add support for WTForms 3.2. The minimum supported WTForms version is now 3.1.0.
 
 
 0.10.5 (2021-01-17)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=[
-        'WTForms>=1.0.4',
+        'WTForms>=3.1.0',
         'six>=1.4.1',
         'email_validator>=1.0.0',
         'validators>=0.21',

--- a/tox.ini
+++ b/tox.ini
@@ -4,12 +4,12 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = {py39,py310,py311,py312}-{wtforms23,wtforms31}
+envlist = {py39,py310,py311,py312}-{wtforms31,wtforms32}
 
 [testenv]
 commands =
     pytest {posargs}
 deps =
     .[test]
-    wtforms23: WTForms>=2.3,<2.4
     wtforms31: WTForms>=3.1,<3.2
+    wtforms32: WTForms>=3.2,<3.3

--- a/wtforms_components/fields/select.py
+++ b/wtforms_components/fields/select.py
@@ -42,7 +42,7 @@ class SelectField(_SelectField):
         internal list or tuple should be selected.
         """
         for value, label in self.concrete_choices:
-            yield (value, label, (self.coerce, self.data))
+            yield (value, label, (self.coerce, self.data), {})
 
     @property
     def concrete_choices(self):

--- a/wtforms_components/widgets.py
+++ b/wtforms_components/widgets.py
@@ -61,6 +61,8 @@ def has_validator(field, validator_class):
 
 
 class HTML5Input(Input):
+    validation_attrs = ['required', 'disabled']
+
     def __init__(self, **kwargs):
         self.options = kwargs
 


### PR DESCRIPTION
Add support for WTForms 3.2 by making the following changes:

- Change `SelectField.iter_choices` to yield 4-item tuples instead to make the API compatible with WTForms 3.2.
- Add `validation_attrs` attribute to `HTML5Input` due to `Input.validation_attrs` being removed in WTForms 3.2.

The minimum supported WTForms version is now 3.1.0.

Fixes #76.