### PR TITLE
Remove six dependency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,7 @@ UNRELEASED
 - Add support for Python 3.9, 3.10, 3.11 and 3.12.
 - Drop support for Python 3.8 or older.
 - Add support for WTForms 3.2. The minimum supported WTForms version is now 3.1.0.
+- Remove `six` dependency.
 
 
 0.10.5 (2021-01-17)

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,6 @@ setup(
     platforms='any',
     install_requires=[
         'WTForms>=3.1.0',
-        'six>=1.4.1',
         'email_validator>=1.0.0',
         'validators>=0.21',
         'intervals>=0.6.0',

--- a/wtforms_components/fields/ajax.py
+++ b/wtforms_components/fields/ajax.py
@@ -1,6 +1,5 @@
 import operator
 
-import six
 from wtforms import fields, widgets
 from wtforms.validators import ValidationError
 
@@ -45,7 +44,7 @@ class AjaxField(fields.Field):
 
         if get_label is None:
             self.get_label = lambda x: x
-        elif isinstance(get_label, six.string_types):
+        elif isinstance(get_label, str):
             self.get_label = operator.attrgetter(get_label)
         else:
             self.get_label = get_label

--- a/wtforms_components/utils.py
+++ b/wtforms_components/utils.py
@@ -1,12 +1,9 @@
-import six
-
-
 def is_scalar(value):
-    return isinstance(value, (type(None), six.string_types, int, float, bool))
+    return isinstance(value, (type(None), str, int, float, bool))
 
 
 def null_or_unicode(value):
-    return six.text_type(value) or None
+    return str(value) or None
 
 
 def null_or_int(value):

--- a/wtforms_components/widgets.py
+++ b/wtforms_components/widgets.py
@@ -1,6 +1,5 @@
 from copy import copy
 
-import six
 from wtforms.validators import DataRequired, NumberRange
 from wtforms.widgets import Input, html_params
 from wtforms.widgets import Select as _Select
@@ -263,7 +262,7 @@ class SelectWidget(_Select):
             children.append(item_html)
 
         html = '<optgroup label="%s">%s</optgroup>'
-        data = (html_escape(six.text_type(value)), "\n".join(children))
+        data = (html_escape(str(value)), "\n".join(children))
         return HTMLString(html % data)
 
     @classmethod
@@ -291,6 +290,6 @@ class SelectWidget(_Select):
             options["selected"] = True
 
         html = "<option %s>%s</option>"
-        data = (html_params(**options), html_escape(six.text_type(label)))
+        data = (html_params(**options), html_escape(str(label)))
 
         return HTMLString(html % data)


### PR DESCRIPTION
Python 2 is no longer supported, so remove the `six` dependency and any references to it.