### PR TITLE
Remove try..except from email validator import

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,7 @@ UNRELEASED
 - Add support for WTForms 3.2. The minimum supported WTForms version is now 3.1.0.
 - Remove `email_validator` and `six` dependencies.
 - Remove `_compat` and `utils` modules.
+- Remove `try..except` from email validator import.
 
 
 0.10.5 (2021-01-17)

--- a/wtforms_components/validators.py
+++ b/wtforms_components/validators.py
@@ -1,10 +1,6 @@
+from validators import email
 from wtforms import ValidationError
 from wtforms.validators import StopValidation
-
-try:
-    from validators import email
-except ImportError:
-    from validators import is_email as email
 
 
 class ControlStructure:


### PR DESCRIPTION
The `is_email` function existed in `validators` 0.1.0. We depend on `validators` 0.21 or newer so the `try..except` is redundant.